### PR TITLE
Add CLI argument for video path

### DIFF
--- a/LPR_Project/LPR_TH-main/README.md
+++ b/LPR_Project/LPR_TH-main/README.md
@@ -42,11 +42,14 @@ pip list
 
 ## การใช้งาน
 
-1. แก้ไขตัวแปร `video_path` ที่ท้ายไฟล์ `LPR_TH/app.py` ให้ชี้ไปยังไฟล์วิดีโอของคุณ
+1. ระบุแหล่งวิดีโอด้วยอาร์กิวเมนต์ `--video` หรือกำหนดตัวแปรสภาพแวดล้อม `VIDEO_PATH`
 2. เริ่มต้นฐานข้อมูลและรันแอปพลิเคชัน (เมื่อรันครั้งแรกจะสร้างไฟล์ `vehicle.db` ให้อัตโนมัติ)
 
 ```bash
-python LPR_TH/app.py
+# ใช้ argument
+python LPR_TH/app.py --video /path/to/video.mp4
+# หรือใช้ตัวแปรสภาพแวดล้อม
+VIDEO_PATH=/path/to/video.mp4 python LPR_TH/app.py
 ```
 
 ### เติมข้อมูลตัวอย่าง

--- a/LPR_Project/LPR_TH-main/app.py
+++ b/LPR_Project/LPR_TH-main/app.py
@@ -368,9 +368,17 @@ def clear_cache():
     detector.last_detection_time = 0  # รีเซ็ตเวลาการตรวจจับล่าสุด (เพื่อให้ cooldown ไม่มีผลทันที)
     return jsonify({"status": "success", "message": "Cache cleared successfully"}) # คืนค่าสถานะความสำเร็จ
 
-if __name__ == '__main__': 
-    video_path = r"C:\Users\suranan\Desktop\LPR_Project\LPR_TH-main\video\Untitled video - Made with Clipchamp.mp4" # กำหนด path ของไฟล์วิดีโอ
-    detector.start_video(video_path)  # เริ่มการประมวลผลวิดีโอด้วยไฟล์ที่กำหนด
+if __name__ == '__main__':
+    import argparse
+    import os
+
+    parser = argparse.ArgumentParser(description='License Plate Recognition server')
+    parser.add_argument('--video', help='Path to video file or camera index')
+    args = parser.parse_args()
+
+    video_path = args.video or os.getenv('VIDEO_PATH', 'video/default.mp4')
+    detector.start_video(video_path)
+
     # รัน Flask development server
     # host='0.0.0.0' ทำให้สามารถเข้าถึงได้จากทุก IP address ในเครือข่าย
     # port=5000 กำหนด port ที่จะรัน server


### PR DESCRIPTION
## Summary
- support command-line `--video` or `VIDEO_PATH` env var in `app.py`
- document providing the video source in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a16209f48324ab3333e73555a168