### PR TITLE
Add configurable video path

### DIFF
--- a/LPR_Project/LPR_TH-main/README.md
+++ b/LPR_Project/LPR_TH-main/README.md
@@ -42,11 +42,13 @@ pip list
 
 ## การใช้งาน
 
-1. แก้ไขตัวแปร `video_path` ที่ท้ายไฟล์ `LPR_TH/app.py` ให้ชี้ไปยังไฟล์วิดีโอของคุณ
+1. กำหนด path วิดีโอด้วยตัวแปรสภาพแวดล้อม `VIDEO_PATH` หรือส่งพารามิเตอร์ `--video` ขณะรัน `app.py`
 2. เริ่มต้นฐานข้อมูลและรันแอปพลิเคชัน (เมื่อรันครั้งแรกจะสร้างไฟล์ `vehicle.db` ให้อัตโนมัติ)
 
 ```bash
-python LPR_TH/app.py
+VIDEO_PATH=/path/to/video.mp4 python LPR_TH/app.py
+# หรือ
+python LPR_TH/app.py --video /path/to/video.mp4
 ```
 
 ### เติมข้อมูลตัวอย่าง

--- a/LPR_Project/LPR_TH-main/app.py
+++ b/LPR_Project/LPR_TH-main/app.py
@@ -1,6 +1,8 @@
 # นำเข้าไลบรารีที่จำเป็น
 from flask import Flask, Response, jsonify, render_template, request
 import cv2
+import os
+import argparse
 from ultralytics import YOLO
 from function.helper import get_thai_character, data_province, split_license_plate_and_province
 from function.database import (
@@ -368,9 +370,16 @@ def clear_cache():
     detector.last_detection_time = 0  # รีเซ็ตเวลาการตรวจจับล่าสุด (เพื่อให้ cooldown ไม่มีผลทันที)
     return jsonify({"status": "success", "message": "Cache cleared successfully"}) # คืนค่าสถานะความสำเร็จ
 
-if __name__ == '__main__': 
-    video_path = r"C:\Users\suranan\Desktop\LPR_Project\LPR_TH-main\video\Untitled video - Made with Clipchamp.mp4" # กำหนด path ของไฟล์วิดีโอ
-    detector.start_video(video_path)  # เริ่มการประมวลผลวิดีโอด้วยไฟล์ที่กำหนด
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Thai license plate recognition service')
+    parser.add_argument('--video', dest='video_path', help='Path to video file')
+    args = parser.parse_args()
+
+    video_path = args.video_path or os.getenv('VIDEO_PATH')
+    if not video_path:
+        raise SystemExit('Please provide a video path using --video or the VIDEO_PATH environment variable')
+
+    detector.start_video(video_path)
     # รัน Flask development server
     # host='0.0.0.0' ทำให้สามารถเข้าถึงได้จากทุก IP address ในเครือข่าย
     # port=5000 กำหนด port ที่จะรัน server


### PR DESCRIPTION
## Summary
- allow specifying a video path for `app.py` via `--video` flag or `VIDEO_PATH` environment variable
- document the new usage in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a45aa0b48324b8f3b27cee2dc3b1