### PR TITLE
Add license and expand README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Saitosamasama
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # LPR_Project
-Car plate recognition  #Thai plate
+
+This repository contains a simple Thai license plate recognition system built
+with YOLO and Flask. The main application and detailed installation
+instructions live in [`LPR_Project/LPR_TH-main`](LPR_Project/LPR_TH-main/README.md).
+
+See that directory for setup guides, usage examples and API information.


### PR DESCRIPTION
## Summary
- add MIT `LICENSE`
- expand short README with description and link to subproject

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a4c0d224832496699de23cf37c3b